### PR TITLE
Feat/pass create register

### DIFF
--- a/src/application/services/admin.service.spec.ts
+++ b/src/application/services/admin.service.spec.ts
@@ -4,22 +4,32 @@ import { StellarService } from '../../infrastructure/stellar/stellar.service'
 import { PlatformService } from './platform.service';
 import { StellarTransactionQueue } from './stellar-transaction-queue.service';
 import { FailedStellarTxRepository } from '../../infrastructure/firebase/failed-stellar-tx.repository';
+import { UserService } from './user.service';
 import { 
   BuildRegisterTransactionDto,
   SubmitSignedTransactionDto,
   BuildCreateVerificationTransactionDto
 } from '../../domain/entities/admin.entity';
+import { CreatePassDto } from '../../domain/entities/pass.entity';
 
 describe('AdminService', () => {
   let service: AdminService;
   let stellarService: jest.Mocked<StellarService>;
   let platformService: jest.Mocked<PlatformService>;
+  let failedTxRepository: jest.Mocked<FailedStellarTxRepository>;
+  let userService: jest.Mocked<UserService>;
 
   beforeEach(async () => {
     const mockStellarService = {
       buildRegisterTransaction: jest.fn(),
       submitSignedTransaction: jest.fn(),
       buildCreateVerificationTransaction: jest.fn(),
+      validateWalletAddress: jest.fn().mockReturnValue(true),
+      submitRegisterWithRetry: jest.fn(),
+    };
+
+    const mockUserService = {
+      create: jest.fn(),
     };
 
     const mockPlatformService = {
@@ -60,12 +70,18 @@ describe('AdminService', () => {
           provide: FailedStellarTxRepository,
           useValue: mockFailedTxRepository,
         },
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
       ],
     }).compile();
 
     service = module.get<AdminService>(AdminService);
     stellarService = module.get(StellarService);
     platformService = module.get(PlatformService);
+    failedTxRepository = module.get(FailedStellarTxRepository);
+    userService = module.get(UserService);
 
     jest.clearAllMocks();
   });
@@ -396,6 +412,136 @@ describe('AdminService', () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe('Failed to generate API key: Network error');
       expect(result.error).toBe('Network error');
+    });
+  });
+
+  describe('createPass', () => {
+    const wallet = 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890';
+    const sourceAccount = 'GXYZ9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210ZYXWVUTSRQP';
+
+    it('registers a wallet on-chain and persists the identity', async () => {
+      const dto: CreatePassDto = {
+        wallet,
+        sourceAccount,
+        name: 'John',
+        surnames: 'Doe',
+      };
+
+      stellarService.submitRegisterWithRetry.mockResolvedValue({
+        success: true,
+        transactionHash: 'tx-hash-123',
+        attempts: 1,
+      });
+      userService.create.mockResolvedValue({} as any);
+
+      const result = await service.createPass(dto);
+
+      expect(stellarService.submitRegisterWithRetry).toHaveBeenCalledWith({
+        wallet,
+        name: 'John',
+        surnames: 'Doe',
+        sourceAccount,
+      });
+      expect(userService.create).toHaveBeenCalledWith({
+        walletAddress: wallet,
+        name: 'John',
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          transactionHash: 'tx-hash-123',
+        }),
+      );
+      expect(failedTxRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('returns alreadyRegistered (409 signal) without dead-lettering', async () => {
+      const dto: CreatePassDto = {
+        wallet,
+        sourceAccount,
+        name: 'John',
+        surnames: 'Doe',
+      };
+
+      stellarService.submitRegisterWithRetry.mockResolvedValue({
+        success: false,
+        alreadyRegistered: true,
+        attempts: 1,
+        lastError: 'AlreadyRegistered',
+      });
+
+      const result = await service.createPass(dto);
+
+      expect(result.success).toBe(false);
+      expect(result.alreadyRegistered).toBe(true);
+      expect(failedTxRepository.create).not.toHaveBeenCalled();
+      expect(userService.create).not.toHaveBeenCalled();
+    });
+
+    it('dead-letters after exhausted retries', async () => {
+      const dto: CreatePassDto = {
+        wallet,
+        sourceAccount,
+        name: 'John',
+        surnames: 'Doe',
+      };
+
+      stellarService.submitRegisterWithRetry.mockResolvedValue({
+        success: false,
+        attempts: 5,
+        lastError: 'network error',
+      });
+
+      const result = await service.createPass(dto);
+
+      expect(failedTxRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          wallet,
+          operation: 'register',
+          resolved: false,
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.alreadyRegistered).toBeFalsy();
+    });
+  });
+
+  describe('retryFailedStellarTx (register)', () => {
+    it('retries a dead-lettered register operation and marks it resolved', async () => {
+      const wallet = 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890';
+      const sourceAccount = 'GXYZ9876543210ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210ZYXWVUTSRQP';
+
+      failedTxRepository.findById.mockResolvedValue({
+        id: 'rec1',
+        wallet,
+        operation: 'register',
+        payload: {
+          sourceAccount,
+          name: 'John',
+          surnames: 'Doe',
+        },
+        idempotencyKey: 'k',
+        attempts: 5,
+        lastError: 'network error',
+        resolved: false,
+        createdAt: new Date(),
+      } as any);
+      stellarService.submitRegisterWithRetry.mockResolvedValue({
+        success: true,
+        transactionHash: 'retry-hash',
+        attempts: 1,
+      });
+
+      const result = await service.retryFailedStellarTx('rec1');
+
+      expect(stellarService.submitRegisterWithRetry).toHaveBeenCalledWith({
+        wallet,
+        name: 'John',
+        surnames: 'Doe',
+        sourceAccount,
+      });
+      expect(failedTxRepository.markResolved).toHaveBeenCalledWith('rec1', 'retry-hash');
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/src/application/services/admin.service.ts
+++ b/src/application/services/admin.service.ts
@@ -7,6 +7,7 @@ import {
   StatusResponse,
 } from '../../infrastructure/stellar/stellar.service'
 import { PlatformService } from './platform.service';
+import { UserService } from './user.service';
 import { StellarTransactionQueue } from './stellar-transaction-queue.service';
 import { FailedStellarTxRepository } from '../../infrastructure/firebase/failed-stellar-tx.repository';
 import { 
@@ -25,6 +26,7 @@ import {
 } from '../../domain/entities/admin.entity';
 import { ApiKeyRequestDto, ApiKeyResponse as HumanApiKeyResponse } from '../../domain/entities/api-key.entity';
 import { RetryStellarTxResponse } from '../../domain/entities/failed-stellar-tx.entity';
+import { CreatePassDto, CreatePassResponse, CreatePassOptions } from '../../domain/entities/pass.entity';
 
 @Injectable()
 export class AdminService {
@@ -35,6 +37,7 @@ export class AdminService {
     private readonly platformService: PlatformService,
     private readonly stellarQueue: StellarTransactionQueue,
     private readonly failedTxRepository: FailedStellarTxRepository,
+    private readonly userService: UserService,
   ) {}
 
 
@@ -551,6 +554,121 @@ export class AdminService {
   }
 
   /**
+   * Register a wallet's identity on-chain (admin-sponsored), routed through the
+   * serial Stellar transaction queue with retry/backoff and idempotency.
+   * On success persists the identity in Firestore (users collection).
+   */
+  async createPass(
+    dto: CreatePassDto,
+    options?: CreatePassOptions,
+  ): Promise<CreatePassResponse> {
+    const operation = 'register';
+
+    try {
+      this.logger.log(
+        `Creating pass (register) for wallet: ${dto.wallet}, source: ${dto.sourceAccount}`,
+      );
+
+      if (!this.stellarService.validateWalletAddress(dto.wallet)) {
+        return { success: false, message: 'Invalid wallet address format', error: 'Invalid wallet address format' };
+      }
+      if (!this.stellarService.validateWalletAddress(dto.sourceAccount)) {
+        return { success: false, message: 'Invalid source account format', error: 'Invalid source account format' };
+      }
+
+      // A wallet can only register once -> idempotency keyed on wallet:register
+      const idempotencyKey =
+        options?.idempotencyKey ??
+        crypto.createHash('sha256').update(`${dto.wallet}:${operation}`).digest('hex');
+
+      if (this.stellarQueue.hasInFlightKey(idempotencyKey)) {
+        this.logger.log(`Skipping duplicate in-flight register for key=${idempotencyKey}`);
+        return { success: true, skipped: true, message: 'Duplicate registration skipped (already in queue)' };
+      }
+
+      const unresolved = await this.failedTxRepository.findUnresolvedByIdempotencyKey(idempotencyKey);
+      if (unresolved) {
+        this.logger.log(`Skipping duplicate register for unresolved dead-letter key=${idempotencyKey}`);
+        return { success: true, skipped: true, message: 'Duplicate registration skipped (unresolved dead-letter exists)' };
+      }
+
+      const payload = {
+        name: dto.name,
+        surnames: dto.surnames,
+        sourceAccount: dto.sourceAccount,
+      };
+
+      const result = await this.stellarQueue.enqueue(
+        () =>
+          this.stellarService.submitRegisterWithRetry({
+            wallet: dto.wallet,
+            name: dto.name,
+            surnames: dto.surnames,
+            sourceAccount: dto.sourceAccount,
+          }),
+        idempotencyKey,
+      );
+
+      if (result.alreadyRegistered) {
+        this.logger.warn(`Wallet already registered on-chain: ${dto.wallet}`);
+        return {
+          success: false,
+          alreadyRegistered: true,
+          message: 'Wallet is already registered',
+          error: result.lastError,
+        };
+      }
+
+      if (result.success) {
+        this.logger.log(`Wallet registered on-chain: ${dto.wallet}, hash: ${result.transactionHash}`);
+
+        // Persist identity in Firestore (users collection). On-chain is the source
+        // of truth, so a Firestore failure must not fail the request.
+        try {
+          await this.userService.create({ walletAddress: dto.wallet, name: dto.name });
+        } catch (persistError) {
+          this.logger.error(
+            `On-chain register succeeded but Firestore persist failed for wallet=${dto.wallet}`,
+            persistError,
+          );
+        }
+
+        return {
+          success: true,
+          message: 'Identity registered on-chain',
+          transactionHash: result.transactionHash,
+          sourceAccount: dto.sourceAccount,
+        };
+      }
+
+      // Exhausted retries -> dead-letter for later retry via /admin/stellar/retry/:id
+      await this.failedTxRepository.create({
+        wallet: dto.wallet,
+        operation,
+        payload,
+        idempotencyKey,
+        attempts: result.attempts,
+        lastError: result.lastError ?? 'Unknown error',
+        resolved: false,
+        createdAt: new Date(),
+      });
+
+      return {
+        success: false,
+        message: `Failed to register identity: ${result.lastError}`,
+        error: result.lastError,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to create pass for wallet: ${dto.wallet}`, error);
+      return {
+        success: false,
+        message: `Failed to register identity: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  /**
    * Re-enqueue a dead-letter Stellar transaction for retry.
    */
   async retryFailedStellarTx(id: string): Promise<RetryStellarTxResponse> {
@@ -574,6 +692,47 @@ export class AdminService {
 
     await this.failedTxRepository.markRetried(id);
 
+    if (record.operation === 'register') {
+      const sourceAccount = record.payload.sourceAccount as string;
+      const name = record.payload.name as string;
+      const surnames = record.payload.surnames as string;
+
+      if (!sourceAccount || name === undefined || surnames === undefined) {
+        return {
+          success: false,
+          message: 'Dead-letter payload missing sourceAccount, name, or surnames',
+          error: 'INVALID_PAYLOAD',
+        };
+      }
+
+      const result = await this.stellarQueue.enqueue(() =>
+        this.stellarService.submitRegisterWithRetry({
+          wallet: record.wallet,
+          name,
+          surnames,
+          sourceAccount,
+        }),
+      );
+
+      if (result.success || result.alreadyRegistered) {
+        await this.failedTxRepository.markResolved(id, result.transactionHash);
+        return {
+          success: true,
+          message: result.alreadyRegistered
+            ? 'Wallet already registered on-chain; dead-letter resolved'
+            : 'Dead-letter register retried successfully',
+          transactionHash: result.transactionHash,
+        };
+      }
+
+      return {
+        success: false,
+        message: `Retry failed: ${result.lastError}`,
+        error: result.lastError,
+      };
+    }
+
+    // Default: upsert_verification (existing behavior)
     const sourceAccount = record.payload.sourceAccount as string;
     const status = record.payload.status as StatusType;
 

--- a/src/application/services/stellar-queue.integration.spec.ts
+++ b/src/application/services/stellar-queue.integration.spec.ts
@@ -6,6 +6,7 @@ import { StellarTransactionQueue } from './stellar-transaction-queue.service';
 import { FailedStellarTxRepository } from '../../infrastructure/firebase/failed-stellar-tx.repository';
 import { AdminService } from './admin.service';
 import { PlatformService } from './platform.service';
+import { UserService } from './user.service';
 import * as crypto from 'crypto';
 
 describe('StellarService submitVerificationWithRetry', () => {
@@ -145,6 +146,7 @@ describe('AdminService idempotency and queue routing', () => {
         StellarTransactionQueue,
         { provide: StellarService, useValue: stellarService },
         { provide: PlatformService, useValue: { isHuman: jest.fn() } },
+        { provide: UserService, useValue: { create: jest.fn() } },
         { provide: FailedStellarTxRepository, useValue: failedTxRepository },
       ],
     }).compile();

--- a/src/domain/entities/failed-stellar-tx.entity.ts
+++ b/src/domain/entities/failed-stellar-tx.entity.ts
@@ -26,4 +26,5 @@ export interface SubmitVerificationResult {
   lastError?: string;
   skipped?: boolean;
   message?: string;
+  alreadyRegistered?: boolean;
 }

--- a/src/domain/entities/pass.entity.ts
+++ b/src/domain/entities/pass.entity.ts
@@ -1,0 +1,52 @@
+import { IsString, IsNotEmpty, Matches, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreatePassDto {
+  @ApiProperty({
+    description: 'The wallet to register on-chain',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message: 'wallet must be a valid Stellar public key (G...)',
+  })
+  wallet: string;
+
+  @ApiProperty({
+    description: 'The admin-sponsoring source account',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message: 'sourceAccount must be a valid Stellar public key (G...)',
+  })
+  sourceAccount: string;
+
+  @ApiProperty({ description: 'Given name of the identity holder', maxLength: 64 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(64)
+  name: string;
+
+  @ApiProperty({ description: 'Surnames of the identity holder', maxLength: 128 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  surnames: string;
+}
+
+export interface CreatePassResponse {
+  success: boolean;
+  message: string;
+  transactionHash?: string;
+  sourceAccount?: string;
+  alreadyRegistered?: boolean;
+  skipped?: boolean;
+  error?: string;
+}
+
+export interface CreatePassOptions {
+  idempotencyKey?: string;
+}

--- a/src/infrastructure/stellar/stellar.service.ts
+++ b/src/infrastructure/stellar/stellar.service.ts
@@ -157,9 +157,9 @@ export class StellarService implements PassportPort {
    */
   private createClient(address: string): StellarPassportClient {
     return new StellarPassportClient({
-      contractId: networks.testnet.contractId,
-      networkPassphrase: networks.testnet.networkPassphrase,
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      contractId: this.contractId,
+      networkPassphrase: this.networkPassphrase,
+      rpcUrl: this.rpcUrl,
       publicKey: address,
     });
   }
@@ -1052,6 +1052,68 @@ export class StellarService implements PassportPort {
     return { success: false, attempts: maxRetries, lastError };
   }
 
+  async submitRegisterWithRetry(params: {
+    wallet: string;
+    name: string;
+    surnames: string;
+    sourceAccount: string;
+  }): Promise<SubmitVerificationResult> {
+    const maxRetries = Number(
+      this.configService.get<string>('STELLAR_TX_MAX_RETRIES', '5'),
+    );
+    const backoffBaseMs = Number(
+      this.configService.get<string>('STELLAR_TX_BACKOFF_BASE_MS', '300'),
+    );
+
+    if (!this.adminKeypair) {
+      return {
+        success: false,
+        attempts: 0,
+        lastError: 'Admin keypair not configured (STELLAR_ADMIN_SECRET_KEY)',
+      };
+    }
+
+    if (this.adminKeypair.publicKey() !== params.sourceAccount) {
+      return {
+        success: false,
+        attempts: 0,
+        lastError:
+          'ADMIN_SOURCE_ACCOUNT does not match STELLAR_ADMIN_SECRET_KEY public key',
+      };
+    }
+
+    let lastError = 'Unknown error';
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const transactionHash = await this.buildSignAndSubmitRegister(params);
+        return { success: true, transactionHash, attempts: attempt };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Submit attempt ${attempt}/${maxRetries} failed for wallet=${params.wallet}: ${lastError}`,
+        );
+
+        if (this.isAlreadyRegisteredError(lastError)) {
+          return { success: false, attempts: attempt, lastError, alreadyRegistered: true };
+        }
+
+        if (!this.isRetriableError(lastError) || attempt === maxRetries) {
+          break;
+        }
+
+        const delayMs = backoffBaseMs * Math.pow(2, attempt - 1);
+        await this.sleep(delayMs);
+      }
+    }
+
+    this.logger.error(
+      `Exhausted retries for wallet=${params.wallet} operation=register: ${lastError}`,
+    );
+
+    return { success: false, attempts: maxRetries, lastError };
+  }
+
   private async buildSignAndSubmitVerification(params: {
     wallet: string;
     verification: Verification;
@@ -1091,6 +1153,49 @@ export class StellarService implements PassportPort {
       `Verification submitted on-chain for wallet=${params.wallet}, hash=${hash}`,
     );
     return hash;
+  }
+
+  private async buildSignAndSubmitRegister(params: {
+    wallet: string;
+    name: string;
+    surnames: string;
+    sourceAccount: string;
+  }): Promise<string> {
+    const client = new StellarPassportClient({
+      contractId: this.contractId,
+      networkPassphrase: this.networkPassphrase,
+      rpcUrl: this.rpcUrl,
+      publicKey: params.sourceAccount,
+      signTransaction: async (txXdr: string) => {
+        const tx = TransactionBuilder.fromXDR(txXdr, this.networkPassphrase);
+        tx.sign(this.adminKeypair!);
+        return { signedTxXdr: tx.toXDR() };
+      },
+    });
+
+    const assembledTx = await client.register(
+      { wallet: params.wallet, name: params.name, surnames: params.surnames },
+      { timeoutInSeconds: 120 },
+    );
+
+    const sent = await assembledTx.signAndSend();
+    const hash = sent.sendTransactionResponse?.hash;
+
+    if (!hash) {
+      throw new Error('Transaction submitted but no hash returned');
+    }
+
+    this.logger.log(`Register submitted on-chain for wallet=${params.wallet}, hash=${hash}`);
+    return hash;
+  }
+
+  private isAlreadyRegisteredError(errorMessage: string): boolean {
+    const lower = errorMessage.toLowerCase();
+    return (
+      lower.includes('alreadyregistered') ||
+      lower.includes('already registered') ||
+      /error\(contract,\s*#1\)/i.test(errorMessage)
+    );
   }
 
   private isRetriableError(errorMessage: string): boolean {

--- a/src/interfaces/controllers/pass.controller.ts
+++ b/src/interfaces/controllers/pass.controller.ts
@@ -1,9 +1,22 @@
-import { Controller, Get } from '@nestjs/common'
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  ConflictException,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { AdminService } from '../../application/services/admin.service';
+import { CreatePassDto } from '../../domain/entities/pass.entity';
+import { SubmitSignedTransactionDto } from '../../domain/entities/admin.entity';
 
 @ApiTags('pass')
 @Controller('pass')
 export class PassController {
+  constructor(private readonly adminService: AdminService) {}
+
   @Get()
   @ApiOperation({ summary: 'Passport route group status' })
   @ApiResponse({
@@ -17,5 +30,44 @@ export class PassController {
       message: 'Identity endpoints will be available in upcoming releases',
       timestamp: new Date().toISOString(),
     }
+  }
+
+  @Post('create')
+  @ApiOperation({ summary: 'Register a wallet identity on-chain (admin-sponsored)' })
+  @ApiResponse({ status: 201, description: 'Identity registered on-chain' })
+  @ApiResponse({ status: 409, description: 'Wallet already registered' })
+  @ApiResponse({
+    status: 502,
+    description: 'On-chain registration failed (dead-lettered for retry)',
+  })
+  @ApiBody({ type: CreatePassDto })
+  async createPass(@Body() dto: CreatePassDto) {
+    const result = await this.adminService.createPass(dto);
+
+    if (result.alreadyRegistered) {
+      throw new ConflictException(result.message);
+    }
+
+    if (!result.success) {
+      throw new HttpException(result.message, HttpStatus.BAD_GATEWAY);
+    }
+
+    return result;
+  }
+
+  @Post('create/build')
+  @ApiOperation({ summary: 'Build an unsigned register transaction (client-signed)' })
+  @ApiResponse({ status: 201 })
+  @ApiBody({ type: CreatePassDto })
+  async buildCreatePass(@Body() dto: CreatePassDto) {
+    return this.adminService.buildRegisterTransaction(dto);
+  }
+
+  @Post('create/submit')
+  @ApiOperation({ summary: 'Submit a signed register transaction' })
+  @ApiResponse({ status: 201 })
+  @ApiBody({ type: SubmitSignedTransactionDto })
+  async submitCreatePass(@Body() dto: SubmitSignedTransactionDto) {
+    return this.adminService.submitSignedTransaction(dto);
   }
 }

--- a/src/modules/admin.module.ts
+++ b/src/modules/admin.module.ts
@@ -3,9 +3,10 @@ import { AdminController } from '../interfaces/controllers/admin.controller';
 import { StellarAdminController } from '../interfaces/controllers/stellar-admin.controller';
 import { AdminService } from '../application/services/admin.service';
 import { PlatformModule } from './platform.module';
+import { UserModule } from './user.module';
 
 @Module({
-  imports: [PlatformModule],
+  imports: [PlatformModule, UserModule],
   controllers: [AdminController, StellarAdminController],
   providers: [AdminService],
   exports: [AdminService],

--- a/src/modules/pass.module.ts
+++ b/src/modules/pass.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common'
 import { PassController } from '../interfaces/controllers/pass.controller'
+import { AdminModule } from '../modules/admin.module'
 
 @Module({
+  imports: [AdminModule],
   controllers: [PassController],
 })
 export class PassModule {}


### PR DESCRIPTION
## Context

Implements the core identity-creation flow: a user's on-chain Veridion identity is created by calling the Passport contract's `register(wallet, name, surnames)`. Mirrors the existing `updateStatus` design (admin-signed submit, serial queue, retry-with-backoff, idempotency, dead-letter) which the register path previously lacked.

closes #38

## What's included

- **`POST /pass/create`** (admin-sponsored): builds, admin-signs, submits on-chain with retry/backoff, and persists the identity in Firestore (`users` collection) on success. Returns the transaction hash.
- **`StellarService.submitRegisterWithRetry`**: honors the configured `contractId` / `networkPassphrase` / `rpcUrl` (no more hard-coded testnet), simulates + assembles, admin-signs, and submits through `StellarTransactionQueue`.
- **Fix**: `createClient` no longer hard-codes testnet — it now respects `STELLAR_CONTRACT_ID` / `STELLAR_NETWORK` (also fixes the existing register build path).
- **Idempotency**: keyed on `wallet:register`; `AlreadyRegistered (#1)` surfaces as a clean **409 Conflict** instead of a 500.
- **Dead-letter**: exhausted retries write a `FailedStellarTx` (operation `register`), retryable via `POST /admin/stellar/retry/:id` (handler extended to support `register`).
- **Validation + Swagger**: `CreatePassDto` validates wallet/sourceAccount as Stellar `G…` addresses (regex, not just length 56) and bounds `name`/`surnames`; full Swagger decorators.
- **Optional non-custodial variant**: `POST /pass/create/build` + `POST /pass/create/submit`, fixed to honor configured network/contract.

## Acceptance criteria

- [x] `POST /pass/create` registers on the **configured** network/contract and returns the tx hash
- [x] Re-registering an already-registered wallet returns **409**, not 500
- [x] Transient failures retry with backoff; permanent failures create a dead-letter record retryable through the admin retry endpoint
- [x] On success an identity record is persisted in Firestore
- [x] DTO rejects malformed Stellar addresses; Swagger `/docs` documents the endpoint
- [x] Unit tests cover success, already-registered (409), and retry→dead-letter paths with Soroban mocked

## Testing

- Build passes (`nest build`)
- Full suite green: **91/91 tests pass**
