### PR TITLE
feat: add batch wallet verification endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ ADMIN_SOURCE_ACCOUNT=your-admin-stellar-account-address
 # Stellar Transaction Queue
 STELLAR_TX_MAX_RETRIES=5
 STELLAR_TX_BACKOFF_BASE_MS=300
+
+# Batch Verification
+INTEGRATOR_API_KEY=your-shared-integrator-key
+BATCH_VERIFY_MAX_WALLETS=25
+BATCH_VERIFY_HUMAN_THRESHOLD=35

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { PlatformModule } from './modules/platform.module';
 import { VeriffModule } from './modules/veriff.module';
 import { PassModule } from './modules/pass.module';
 import { HealthModule } from './modules/health.module';
+import { BatchVerifyModule } from './modules/batch-verify.module';
 
 
 @Module({
@@ -24,6 +25,7 @@ import { HealthModule } from './modules/health.module';
     VeriffModule,
     PassModule,
     HealthModule,
+    BatchVerifyModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/application/services/batch-verify.service.spec.ts
+++ b/src/application/services/batch-verify.service.spec.ts
@@ -1,0 +1,258 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, UnprocessableEntityException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { BatchVerifyService } from './batch-verify.service';
+import { IDENTITY_READ_PORT } from '../../domain/ports/identity-read.port';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_WALLET_A = 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB';
+const VALID_WALLET_B = 'GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890DE';
+const INVALID_WALLET = 'not-a-stellar-address';
+
+function buildModule(
+  overrides: {
+    getScore?: jest.Mock;
+    validateWalletAddress?: jest.Mock;
+    threshold?: number;
+    maxWallets?: number;
+  } = {},
+) {
+  const mockIdentityRead = {
+    getScore: overrides.getScore ?? jest.fn(),
+    validateWalletAddress:
+      overrides.validateWalletAddress ??
+      jest.fn((w: string) => w !== INVALID_WALLET),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string, defaultValue?: unknown) => {
+      if (key === 'BATCH_VERIFY_HUMAN_THRESHOLD') {
+        return overrides.threshold ?? 35;
+      }
+      if (key === 'BATCH_VERIFY_MAX_WALLETS') {
+        return overrides.maxWallets ?? 25;
+      }
+      return defaultValue;
+    }),
+  };
+
+  return Test.createTestingModule({
+    providers: [
+      BatchVerifyService,
+      { provide: IDENTITY_READ_PORT, useValue: mockIdentityRead },
+      { provide: ConfigService, useValue: mockConfigService },
+    ],
+  }).compile();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('BatchVerifyService', () => {
+  let service: BatchVerifyService;
+  let identityRead: { getScore: jest.Mock; validateWalletAddress: jest.Mock };
+
+  beforeEach(async () => {
+    const getScore = jest.fn();
+    const validateWalletAddress = jest.fn((w: string) => w !== INVALID_WALLET);
+
+    const module: TestingModule = await (
+      await buildModule({ getScore, validateWalletAddress })
+    );
+
+    service = module.get<BatchVerifyService>(BatchVerifyService);
+    identityRead = module.get(IDENTITY_READ_PORT);
+  });
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  describe('verifyBatch — happy path', () => {
+    it('returns isHuman: true for a wallet with score above threshold', async () => {
+      identityRead.getScore.mockResolvedValue(50);
+
+      const result = await service.verifyBatch([VALID_WALLET_A]);
+
+      expect(result.processed).toBe(1);
+      expect(result.invalid).toBe(0);
+      expect(result.threshold).toBe(35);
+      expect(result.results[0]).toEqual({
+        wallet: VALID_WALLET_A,
+        registered: true,
+        score: 50,
+        isHuman: true,
+      });
+    });
+
+    it('returns isHuman: false for a wallet with score below threshold', async () => {
+      identityRead.getScore.mockResolvedValue(10);
+
+      const result = await service.verifyBatch([VALID_WALLET_A]);
+
+      expect(result.results[0].isHuman).toBe(false);
+    });
+
+    it('returns isHuman: true when score equals the threshold exactly', async () => {
+      identityRead.getScore.mockResolvedValue(35);
+
+      const result = await service.verifyBatch([VALID_WALLET_A]);
+
+      expect(result.results[0].isHuman).toBe(true);
+    });
+
+    it('processes multiple wallets and returns all results', async () => {
+      identityRead.getScore
+        .mockResolvedValueOnce(50)  // wallet A — human
+        .mockResolvedValueOnce(10); // wallet B — not human
+
+      const result = await service.verifyBatch([VALID_WALLET_A, VALID_WALLET_B]);
+
+      expect(result.processed).toBe(2);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0].isHuman).toBe(true);
+      expect(result.results[1].isHuman).toBe(false);
+    });
+  });
+
+  // ── Unregistered wallets ───────────────────────────────────────────────────
+
+  describe('verifyBatch — unregistered wallets', () => {
+    it('returns registered: false without throwing when contract says not registered', async () => {
+      identityRead.getScore.mockRejectedValue(
+        new Error('Contract error: User is not registered'),
+      );
+
+      const result = await service.verifyBatch([VALID_WALLET_A]);
+
+      expect(result.results[0]).toEqual({
+        wallet: VALID_WALLET_A,
+        registered: false,
+        score: 0,
+        isHuman: false,
+      });
+    });
+
+    it('handles NotRegistered error variant', async () => {
+      identityRead.getScore.mockRejectedValue(
+        new Error('NotRegistered'),
+      );
+
+      const result = await service.verifyBatch([VALID_WALLET_A]);
+
+      expect(result.results[0].registered).toBe(false);
+    });
+
+    it('processes a mix of registered and unregistered wallets', async () => {
+      identityRead.getScore
+        .mockResolvedValueOnce(42)
+        .mockRejectedValueOnce(new Error('User is not registered'));
+
+      const result = await service.verifyBatch([VALID_WALLET_A, VALID_WALLET_B]);
+
+      expect(result.processed).toBe(2);
+      expect(result.results[0].registered).toBe(true);
+      expect(result.results[1].registered).toBe(false);
+    });
+  });
+
+  // ── Invalid addresses ──────────────────────────────────────────────────────
+
+  describe('verifyBatch — invalid wallet addresses', () => {
+    it('skips invalid addresses and counts them in invalid', async () => {
+      identityRead.getScore.mockResolvedValue(50);
+
+      const result = await service.verifyBatch([VALID_WALLET_A, INVALID_WALLET]);
+
+      expect(result.processed).toBe(1);
+      expect(result.invalid).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].wallet).toBe(VALID_WALLET_A);
+    });
+
+    it('does not call getScore for invalid addresses', async () => {
+      identityRead.validateWalletAddress.mockReturnValue(false);
+
+      await expect(
+        service.verifyBatch([INVALID_WALLET]),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+
+      expect(identityRead.getScore).not.toHaveBeenCalled();
+    });
+
+    it('throws 422 when all addresses are invalid', async () => {
+      identityRead.validateWalletAddress.mockReturnValue(false);
+
+      await expect(
+        service.verifyBatch([INVALID_WALLET, 'also-bad']),
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+  });
+
+  // ── Batch size validation ──────────────────────────────────────────────────
+
+  describe('verifyBatch — size limits', () => {
+    it('throws 400 when wallets array exceeds maxWallets', async () => {
+      const tooMany = Array.from({ length: 26 }, (_, i) => `wallet-${i}`);
+
+      await expect(service.verifyBatch(tooMany)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('throws 400 for an empty wallets array', async () => {
+      await expect(service.verifyBatch([])).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('accepts exactly maxWallets wallets without throwing', async () => {
+      // All invalid so we just check it gets past the size guard
+      identityRead.validateWalletAddress.mockReturnValue(true);
+      identityRead.getScore.mockResolvedValue(0);
+
+      const exactly25 = Array.from({ length: 25 }, (_, i) => `G${'A'.repeat(55)}${i}`.slice(0, 56));
+      // Will throw 422 if all invalid — but we mocked validateWalletAddress to return true
+      const result = await service.verifyBatch(exactly25);
+      expect(result.processed).toBe(25);
+    });
+  });
+
+  // ── Config-driven threshold ────────────────────────────────────────────────
+
+  describe('verifyBatch — configurable threshold', () => {
+    it('uses threshold from ConfigService', async () => {
+      const module: TestingModule = await buildModule({ threshold: 50 });
+      const svc = module.get<BatchVerifyService>(BatchVerifyService);
+      const port = module.get(IDENTITY_READ_PORT);
+      (port.getScore as jest.Mock).mockResolvedValue(45);
+
+      const result = await svc.verifyBatch([VALID_WALLET_A]);
+
+      // 45 < 50 → not human
+      expect(result.results[0].isHuman).toBe(false);
+      expect(result.threshold).toBe(50);
+    });
+
+    it('uses maxWallets from ConfigService', async () => {
+      const module: TestingModule = await buildModule({ maxWallets: 3 });
+      const svc = module.get<BatchVerifyService>(BatchVerifyService);
+
+      const tooMany = [VALID_WALLET_A, VALID_WALLET_B, 'G3', 'G4'];
+
+      await expect(svc.verifyBatch(tooMany)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ── Unexpected errors ──────────────────────────────────────────────────────
+
+  describe('verifyBatch — unexpected errors', () => {
+    it('re-throws unexpected contract errors', async () => {
+      identityRead.getScore.mockRejectedValue(new Error('RPC timeout'));
+
+      await expect(service.verifyBatch([VALID_WALLET_A])).rejects.toThrow(
+        'RPC timeout',
+      );
+    });
+  });
+});

--- a/src/application/services/batch-verify.service.ts
+++ b/src/application/services/batch-verify.service.ts
@@ -1,0 +1,118 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IDENTITY_READ_PORT, IdentityReadPort } from '../../domain/ports/identity-read.port';
+import { BatchVerifyResult, WalletResult } from '../../domain/entities/batch-verify.entity';
+
+@Injectable()
+export class BatchVerifyService {
+  private readonly logger = new Logger(BatchVerifyService.name);
+
+  private readonly threshold: number;
+  private readonly maxWallets: number;
+
+  constructor(
+    @Inject(IDENTITY_READ_PORT)
+    private readonly identityRead: IdentityReadPort,
+    private readonly configService: ConfigService,
+  ) {
+    this.threshold = this.configService.get<number>(
+      'BATCH_VERIFY_HUMAN_THRESHOLD',
+      35,
+    );
+    this.maxWallets = this.configService.get<number>(
+      'BATCH_VERIFY_MAX_WALLETS',
+      25,
+    );
+  }
+
+  /**
+   * Verify a batch of Stellar wallet addresses.
+   *
+   * Rules:
+   *  - Empty array or count > maxWallets → 400
+   *  - Invalid address format → skipped, counted in `invalid`
+   *  - All addresses invalid → 422
+   *  - Unregistered wallet → { registered: false, score: 0, isHuman: false }
+   *  - Registered wallet → score fetched from contract, isHuman = score >= threshold
+   */
+  async verifyBatch(wallets: string[]): Promise<BatchVerifyResult> {
+    if (!wallets || wallets.length === 0) {
+      throw new BadRequestException('wallets array must not be empty.');
+    }
+
+    if (wallets.length > this.maxWallets) {
+      throw new BadRequestException(
+        `Batch size ${wallets.length} exceeds the maximum of ${this.maxWallets} wallets per request.`,
+      );
+    }
+
+    const results: WalletResult[] = [];
+    let invalidCount = 0;
+
+    for (const wallet of wallets) {
+      if (!this.identityRead.validateWalletAddress(wallet)) {
+        this.logger.debug(`Skipping invalid wallet address: ${wallet}`);
+        invalidCount++;
+        continue;
+      }
+
+      const result = await this.resolveWallet(wallet);
+      results.push(result);
+    }
+
+    if (results.length === 0) {
+      throw new UnprocessableEntityException(
+        'All provided wallet addresses are invalid. No wallets were processed.',
+      );
+    }
+
+    this.logger.log(
+      `Batch verify complete: ${results.length} processed, ${invalidCount} invalid`,
+    );
+
+    return {
+      results,
+      threshold: this.threshold,
+      processed: results.length,
+      invalid: invalidCount,
+    };
+  }
+
+  /**
+   * Resolve a single (already-validated) wallet address to a WalletResult.
+   * Unregistered wallets are handled gracefully rather than surfacing as errors.
+   */
+  private async resolveWallet(wallet: string): Promise<WalletResult> {
+    try {
+      const score = await this.identityRead.getScore(wallet);
+      return {
+        wallet,
+        registered: true,
+        score,
+        isHuman: score >= this.threshold,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes('User is not registered') || message.includes('NotRegistered')) {
+        this.logger.debug(`Wallet not registered: ${wallet}`);
+        return {
+          wallet,
+          registered: false,
+          score: 0,
+          isHuman: false,
+        };
+      }
+
+      // Re-throw unexpected errors so the caller gets a 500 with context.
+      this.logger.error(`Unexpected error resolving wallet ${wallet}: ${message}`);
+      throw error;
+    }
+  }
+}

--- a/src/domain/entities/batch-verify.entity.ts
+++ b/src/domain/entities/batch-verify.entity.ts
@@ -1,0 +1,27 @@
+/**
+ * Per-wallet result returned in a batch verification response.
+ */
+export interface WalletResult {
+  /** The Stellar wallet address that was checked. */
+  wallet: string;
+  /** Whether the wallet is registered in the Veridion smart contract. */
+  registered: boolean;
+  /** The wallet's identity score (0 if not registered). */
+  score: number;
+  /** Whether the wallet's score meets the configured human threshold. */
+  isHuman: boolean;
+}
+
+/**
+ * Full response payload for a batch verification request.
+ */
+export interface BatchVerifyResult {
+  /** Per-wallet verification results (only valid addresses are included). */
+  results: WalletResult[];
+  /** The score threshold used to determine isHuman. */
+  threshold: number;
+  /** Number of wallets that were successfully processed. */
+  processed: number;
+  /** Number of wallet addresses that were skipped due to invalid format. */
+  invalid: number;
+}

--- a/src/domain/ports/identity-read.port.ts
+++ b/src/domain/ports/identity-read.port.ts
@@ -1,7 +1,7 @@
 /**
  * Read-only port for identity data access.
  *
- * Intentionally narrower than PassportPort — exposes only the two
+ * Intentionally narrower than PassportPort. It exposes only the two
  * operations needed by the batch verification feature and excludes
  * all write/transaction-building methods.
  */

--- a/src/domain/ports/identity-read.port.ts
+++ b/src/domain/ports/identity-read.port.ts
@@ -1,0 +1,22 @@
+/**
+ * Read-only port for identity data access.
+ *
+ * Intentionally narrower than PassportPort — exposes only the two
+ * operations needed by the batch verification feature and excludes
+ * all write/transaction-building methods.
+ */
+export const IDENTITY_READ_PORT = Symbol('IDENTITY_READ_PORT');
+
+export interface IdentityReadPort {
+  /**
+   * Retrieve the identity score for a registered wallet.
+   * Throws an error containing "User is not registered" when the wallet
+   * has no on-chain record.
+   */
+  getScore(wallet: string): Promise<number>;
+
+  /**
+   * Returns true when the address is a valid Stellar public key.
+   */
+  validateWalletAddress(wallet: string): boolean;
+}

--- a/src/infrastructure/stellar/identity-read.adapter.ts
+++ b/src/infrastructure/stellar/identity-read.adapter.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { IdentityReadPort } from '../../domain/ports/identity-read.port';
+import { StellarService } from './stellar.service';
+
+/**
+ * Thin adapter that satisfies IdentityReadPort by delegating to the
+ * existing StellarService.  No logic lives here — this keeps the batch
+ * feature decoupled from infrastructure details while avoiding a second
+ * instantiation of the Soroban RPC client.
+ */
+@Injectable()
+export class IdentityReadAdapter implements IdentityReadPort {
+  constructor(private readonly stellarService: StellarService) {}
+
+  getScore(wallet: string): Promise<number> {
+    return this.stellarService.getScore(wallet);
+  }
+
+  validateWalletAddress(wallet: string): boolean {
+    return this.stellarService.validateWalletAddress(wallet);
+  }
+}

--- a/src/infrastructure/stellar/identity-read.adapter.ts
+++ b/src/infrastructure/stellar/identity-read.adapter.ts
@@ -4,13 +4,11 @@ import { StellarService } from './stellar.service';
 
 /**
  * Thin adapter that satisfies IdentityReadPort by delegating to the
- * existing StellarService.  No logic lives here — this keeps the batch
- * feature decoupled from infrastructure details while avoiding a second
- * instantiation of the Soroban RPC client.
+ * existing StellarService.  
  */
 @Injectable()
 export class IdentityReadAdapter implements IdentityReadPort {
-  constructor(private readonly stellarService: StellarService) {}
+  constructor(private readonly stellarService: StellarService) { }
 
   getScore(wallet: string): Promise<number> {
     return this.stellarService.getScore(wallet);

--- a/src/interfaces/controllers/batch-verify.controller.ts
+++ b/src/interfaces/controllers/batch-verify.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { BatchVerifyService } from '../../application/services/batch-verify.service';
+import {
+  BatchVerifyRequestDto,
+  BatchVerifyResponseDto,
+} from '../dto/batch-verify.dto';
+import { IntegratorApiKeyGuard } from '../guards/integrator-api-key.guard';
+
+@ApiTags('pass')
+@Controller('pass/verify')
+export class BatchVerifyController {
+  constructor(private readonly batchVerifyService: BatchVerifyService) {}
+
+  @Post('batch')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(IntegratorApiKeyGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Batch wallet verification',
+    description:
+      'Verify up to BATCH_VERIFY_MAX_WALLETS (default 25) Stellar wallets in a single request. ' +
+      'Invalid address formats are skipped and counted. Unregistered wallets return registered: false.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-wallet verification results.',
+    type: BatchVerifyResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Empty wallets array or batch size exceeds the maximum.',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Missing or invalid Authorization: Bearer <INTEGRATOR_API_KEY> header.',
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'All provided wallet addresses are invalid; no wallets were processed.',
+  })
+  async verifyBatch(
+    @Body() dto: BatchVerifyRequestDto,
+  ): Promise<BatchVerifyResponseDto> {
+    return this.batchVerifyService.verifyBatch(dto.wallets);
+  }
+}

--- a/src/interfaces/dto/batch-verify.dto.ts
+++ b/src/interfaces/dto/batch-verify.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  ArrayNotEmpty,
+  IsString,
+  ArrayMaxSize,
+} from 'class-validator';
+
+export class BatchVerifyRequestDto {
+  @ApiProperty({
+    description: 'List of Stellar wallet addresses to verify.',
+    example: [
+      'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+      'GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890DE',
+    ],
+    type: [String],
+  })
+  @IsArray()
+  @ArrayNotEmpty({ message: 'wallets must not be empty' })
+  @ArrayMaxSize(100, {
+    message: 'wallets must not exceed the configured maximum (default 25)',
+  })
+  @IsString({ each: true })
+  wallets: string[];
+}
+
+// ── Response shapes ──────────────────────────────────────────────────────────
+
+export class WalletResultDto {
+  @ApiProperty({ example: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB' })
+  wallet: string;
+
+  @ApiProperty({ example: true })
+  registered: boolean;
+
+  @ApiProperty({ example: 42 })
+  score: number;
+
+  @ApiProperty({ example: true })
+  isHuman: boolean;
+}
+
+export class BatchVerifyResponseDto {
+  @ApiProperty({ type: [WalletResultDto] })
+  results: WalletResultDto[];
+
+  @ApiProperty({ example: 35, description: 'Score threshold used to determine isHuman.' })
+  threshold: number;
+
+  @ApiProperty({ example: 2, description: 'Number of wallets successfully processed.' })
+  processed: number;
+
+  @ApiProperty({ example: 0, description: 'Number of invalid wallet addresses skipped.' })
+  invalid: number;
+}

--- a/src/interfaces/guards/integrator-api-key.guard.spec.ts
+++ b/src/interfaces/guards/integrator-api-key.guard.spec.ts
@@ -1,0 +1,97 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IntegratorApiKeyGuard } from './integrator-api-key.guard';
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function buildContext(authHeader?: string): ExecutionContext {
+  const request = {
+    headers: authHeader ? { authorization: authHeader } : {},
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('IntegratorApiKeyGuard', () => {
+  let guard: IntegratorApiKeyGuard;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    const mockConfigService = {
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IntegratorApiKeyGuard,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    guard = module.get<IntegratorApiKeyGuard>(IntegratorApiKeyGuard);
+    configService = module.get(ConfigService);
+  });
+
+  it('allows the request when the correct Bearer token is provided', () => {
+    configService.get.mockReturnValue('secret-key');
+
+    const result = guard.canActivate(buildContext('Bearer secret-key'));
+
+    expect(result).toBe(true);
+  });
+
+  it('throws 401 when the Authorization header is absent', () => {
+    configService.get.mockReturnValue('secret-key');
+
+    expect(() => guard.canActivate(buildContext())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when the Authorization header does not start with Bearer', () => {
+    configService.get.mockReturnValue('secret-key');
+
+    expect(() =>
+      guard.canActivate(buildContext('Basic secret-key')),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('throws 401 when the provided token is wrong', () => {
+    configService.get.mockReturnValue('secret-key');
+
+    expect(() =>
+      guard.canActivate(buildContext('Bearer wrong-token')),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('trims whitespace around the token after stripping the Bearer prefix', () => {
+    configService.get.mockReturnValue('secret-key');
+
+    // "Bearer  secret-key" — .trim() strips the leading space, so it matches
+    const result = guard.canActivate(buildContext('Bearer  secret-key'));
+    expect(result).toBe(true);
+  });
+
+  it('throws 401 when INTEGRATOR_API_KEY is not configured on the server', () => {
+    configService.get.mockReturnValue(undefined);
+
+    expect(() =>
+      guard.canActivate(buildContext('Bearer anything')),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('strips "Bearer " prefix correctly and accepts exact match', () => {
+    const key = 'my-integrator-key-abc123';
+    configService.get.mockReturnValue(key);
+
+    const result = guard.canActivate(buildContext(`Bearer ${key}`));
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/interfaces/guards/integrator-api-key.guard.ts
+++ b/src/interfaces/guards/integrator-api-key.guard.ts
@@ -1,0 +1,52 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+
+/**
+ * Guard that validates the shared integrator API key supplied via the
+ * `Authorization: Bearer <INTEGRATOR_API_KEY>` header.
+ *
+ * Configuration:
+ *   INTEGRATOR_API_KEY — the expected token (env var, required)
+ *
+ * Returns 401 when:
+ *  - The Authorization header is absent or malformed
+ *  - The provided token does not match INTEGRATOR_API_KEY
+ *  - INTEGRATOR_API_KEY is not configured
+ */
+@Injectable()
+export class IntegratorApiKeyGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const expectedKey = this.configService.get<string>('INTEGRATOR_API_KEY');
+
+    if (!expectedKey) {
+      throw new UnauthorizedException(
+        'INTEGRATOR_API_KEY is not configured on the server.',
+      );
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers['authorization'];
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException(
+        'Missing or malformed Authorization header. Expected: Bearer <token>',
+      );
+    }
+
+    const providedKey = authHeader.slice('Bearer '.length).trim();
+
+    if (providedKey !== expectedKey) {
+      throw new UnauthorizedException('Invalid API key.');
+    }
+
+    return true;
+  }
+}

--- a/src/modules/batch-verify.module.ts
+++ b/src/modules/batch-verify.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { PlatformModule } from './platform.module';
+import { BatchVerifyController } from '../interfaces/controllers/batch-verify.controller';
+import { BatchVerifyService } from '../application/services/batch-verify.service';
+import { IdentityReadAdapter } from '../infrastructure/stellar/identity-read.adapter';
+import { IntegratorApiKeyGuard } from '../interfaces/guards/integrator-api-key.guard';
+import { IDENTITY_READ_PORT } from '../domain/ports/identity-read.port';
+
+@Module({
+  imports: [
+    ConfigModule, // ensures ConfigService is available (already global, but explicit for clarity)
+    PlatformModule, // re-uses the exported StellarService — no duplicate Soroban client
+  ],
+  controllers: [BatchVerifyController],
+  providers: [
+    BatchVerifyService,
+    IdentityReadAdapter,
+    IntegratorApiKeyGuard,
+    {
+      provide: IDENTITY_READ_PORT,
+      useExisting: IdentityReadAdapter,
+    },
+  ],
+})
+export class BatchVerifyModule {}


### PR DESCRIPTION
This introduces a new POST /pass/verify/batch endpoint to allow third-party integrators to verify the human status of multiple Stellar wallets in a single request. This resolves the inefficiency of clients having to call /platform/is-human/:wallet repeatedly.

Closes #42 