### PR TITLE
fix(stellar): jitter retry backoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ ADMIN_SOURCE_ACCOUNT=your-admin-stellar-account-address
 # Stellar Transaction Queue
 STELLAR_TX_MAX_RETRIES=5
 STELLAR_TX_BACKOFF_BASE_MS=300
+STELLAR_TX_BACKOFF_MAX_MS=5000
+STELLAR_TX_BACKOFF_JITTER_RATIO=1
 
 # Batch Verification
 INTEGRATOR_API_KEY=your-shared-integrator-key

--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ FIREBASE_CLIENT_EMAIL=your-service-account@your-project.iam.gserviceaccount.com
 
 # Add your other configuration variables here
 ```
+
+### Stellar Transaction Queue
+
+The Stellar submission path retries transient sequence, timeout, and network
+errors with bounded exponential backoff plus jitter so multiple failed
+submissions do not retry in lockstep against Horizon or Soroban RPC.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STELLAR_TX_MAX_RETRIES` | `5` | Maximum attempts before a transaction is dead-lettered. |
+| `STELLAR_TX_BACKOFF_BASE_MS` | `300` | Base delay used for exponential retry backoff. |
+| `STELLAR_TX_BACKOFF_MAX_MS` | `5000` | Upper bound for any single retry delay. |
+| `STELLAR_TX_BACKOFF_JITTER_RATIO` | `1` | Jitter amount from `0` (deterministic) to `1` (full jitter). |
+
+With the default full jitter, each retry waits for a random delay between `0`
+and the capped exponential delay. The cap keeps the retry window bounded while
+spreading concurrent retries to reduce thundering-herd bursts.
 ## 📖 API Documentation
 
 Once the application is running, visit:

--- a/src/application/services/stellar-queue.integration.spec.ts
+++ b/src/application/services/stellar-queue.integration.spec.ts
@@ -28,6 +28,8 @@ describe('StellarService submitVerificationWithRetry', () => {
               if (key === 'STELLAR_ADMIN_SECRET_KEY') return adminKeypair.secret();
               if (key === 'STELLAR_TX_MAX_RETRIES') return '5';
               if (key === 'STELLAR_TX_BACKOFF_BASE_MS') return '10';
+              if (key === 'STELLAR_TX_BACKOFF_MAX_MS') return '100';
+              if (key === 'STELLAR_TX_BACKOFF_JITTER_RATIO') return '1';
               return defaultValue;
             }),
           },
@@ -38,11 +40,20 @@ describe('StellarService submitVerificationWithRetry', () => {
     service = module.get(StellarService);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('retries on tx_bad_seq and succeeds on second attempt', async () => {
     const buildSpy = jest
       .spyOn(service as any, 'buildSignAndSubmitVerification')
       .mockRejectedValueOnce(new Error('tx_bad_seq'))
       .mockResolvedValueOnce('hash-retry-success');
+    const sleepSpy = jest
+      .spyOn(service as any, 'sleep')
+      .mockResolvedValue(undefined);
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
 
     const result = await service.submitVerificationWithRetry({
       wallet: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
@@ -59,12 +70,16 @@ describe('StellarService submitVerificationWithRetry', () => {
     expect(result.transactionHash).toBe('hash-retry-success');
     expect(result.attempts).toBe(2);
     expect(buildSpy).toHaveBeenCalledTimes(2);
+    expect(sleepSpy).toHaveBeenCalledWith(5);
   });
 
   it('returns failure after max retries exhausted', async () => {
     jest
       .spyOn(service as any, 'buildSignAndSubmitVerification')
       .mockRejectedValue(new Error('tx_bad_seq'));
+    const sleepSpy = jest
+      .spyOn(service as any, 'sleep')
+      .mockResolvedValue(undefined);
 
     const result = await service.submitVerificationWithRetry({
       wallet: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
@@ -80,12 +95,16 @@ describe('StellarService submitVerificationWithRetry', () => {
     expect(result.success).toBe(false);
     expect(result.attempts).toBe(5);
     expect(result.lastError).toContain('tx_bad_seq');
+    expect(sleepSpy).toHaveBeenCalledTimes(4);
   });
 
   it('does not retry permanent errors', async () => {
     const buildSpy = jest
       .spyOn(service as any, 'buildSignAndSubmitVerification')
       .mockRejectedValue(new Error('function_trapped'));
+    const sleepSpy = jest
+      .spyOn(service as any, 'sleep')
+      .mockResolvedValue(undefined);
 
     const result = await service.submitVerificationWithRetry({
       wallet: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
@@ -101,6 +120,41 @@ describe('StellarService submitVerificationWithRetry', () => {
     expect(result.success).toBe(false);
     expect(result.attempts).toBe(5);
     expect(buildSpy).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps retry backoff deterministic when jitter is disabled', () => {
+    const delay = (service as any).calculateRetryDelayMs(3, {
+      baseMs: 100,
+      maxMs: 1000,
+      jitterRatio: 0,
+    });
+
+    expect(delay).toBe(400);
+  });
+
+  it('applies full jitter within the configured maximum delay', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.25);
+
+    const delay = (service as any).calculateRetryDelayMs(4, {
+      baseMs: 100,
+      maxMs: 500,
+      jitterRatio: 1,
+    });
+
+    expect(delay).toBe(125);
+  });
+
+  it('keeps partial jitter inside the expected bounded range', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const delay = (service as any).calculateRetryDelayMs(2, {
+      baseMs: 200,
+      maxMs: 1000,
+      jitterRatio: 0.25,
+    });
+
+    expect(delay).toBe(350);
   });
 });
 

--- a/src/infrastructure/stellar/stellar.service.ts
+++ b/src/infrastructure/stellar/stellar.service.ts
@@ -77,6 +77,12 @@ export interface StatusResponse {
   error?: string;
 }
 
+interface RetryBackoffConfig {
+  baseMs: number;
+  maxMs: number;
+  jitterRatio: number;
+}
+
 @Injectable()
 export class StellarService implements PassportPort {
   private readonly logger = new Logger(StellarService.name);
@@ -1003,9 +1009,7 @@ export class StellarService implements PassportPort {
     const maxRetries = Number(
       this.configService.get<string>('STELLAR_TX_MAX_RETRIES', '5'),
     );
-    const backoffBaseMs = Number(
-      this.configService.get<string>('STELLAR_TX_BACKOFF_BASE_MS', '300'),
-    );
+    const retryBackoff = this.getRetryBackoffConfig();
 
     if (!this.adminKeypair) {
       return {
@@ -1040,7 +1044,7 @@ export class StellarService implements PassportPort {
           break;
         }
 
-        const delayMs = backoffBaseMs * Math.pow(2, attempt - 1);
+        const delayMs = this.calculateRetryDelayMs(attempt, retryBackoff);
         await this.sleep(delayMs);
       }
     }
@@ -1061,9 +1065,7 @@ export class StellarService implements PassportPort {
     const maxRetries = Number(
       this.configService.get<string>('STELLAR_TX_MAX_RETRIES', '5'),
     );
-    const backoffBaseMs = Number(
-      this.configService.get<string>('STELLAR_TX_BACKOFF_BASE_MS', '300'),
-    );
+    const retryBackoff = this.getRetryBackoffConfig();
 
     if (!this.adminKeypair) {
       return {
@@ -1102,7 +1104,7 @@ export class StellarService implements PassportPort {
           break;
         }
 
-        const delayMs = backoffBaseMs * Math.pow(2, attempt - 1);
+        const delayMs = this.calculateRetryDelayMs(attempt, retryBackoff);
         await this.sleep(delayMs);
       }
     }
@@ -1213,6 +1215,55 @@ export class StellarService implements PassportPort {
       lower.includes('502') ||
       lower.includes('504')
     );
+  }
+
+  private getRetryBackoffConfig(): RetryBackoffConfig {
+    const baseMs = this.getNonNegativeConfigNumber(
+      'STELLAR_TX_BACKOFF_BASE_MS',
+      '300',
+    );
+    const maxMs = this.getNonNegativeConfigNumber(
+      'STELLAR_TX_BACKOFF_MAX_MS',
+      '5000',
+    );
+    const jitterRatio = this.clamp(
+      this.getNonNegativeConfigNumber(
+        'STELLAR_TX_BACKOFF_JITTER_RATIO',
+        '1',
+      ),
+      0,
+      1,
+    );
+
+    return { baseMs, maxMs, jitterRatio };
+  }
+
+  private getNonNegativeConfigNumber(key: string, defaultValue: string): number {
+    const value = Number(this.configService.get<string>(key, defaultValue));
+    return Number.isFinite(value) && value >= 0 ? value : Number(defaultValue);
+  }
+
+  private calculateRetryDelayMs(
+    attempt: number,
+    config: RetryBackoffConfig,
+  ): number {
+    const boundedDelayMs = Math.min(
+      config.maxMs,
+      config.baseMs * Math.pow(2, Math.max(0, attempt - 1)),
+    );
+
+    if (config.jitterRatio <= 0 || boundedDelayMs <= 0) {
+      return Math.round(boundedDelayMs);
+    }
+
+    const minimumDelayMs = boundedDelayMs * (1 - config.jitterRatio);
+    const jitterRangeMs = boundedDelayMs - minimumDelayMs;
+
+    return Math.round(minimumDelayMs + Math.random() * jitterRangeMs);
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
   }
 
   private sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

- adds bounded full-jitter retry backoff for transient Stellar transaction submissions
- applies the same retry delay calculation to verification and register submissions
- documents `STELLAR_TX_BACKOFF_MAX_MS` and `STELLAR_TX_BACKOFF_JITTER_RATIO`
- expands queue retry tests to cover deterministic, full-jitter, partial-jitter, capped, retriable, and permanent-error paths

Closes #54.

## Threat / reliability model

Without jitter, many failed Stellar submissions can retry on the same exponential schedule and hammer Horizon or Soroban RPC in bursts. The new bounded jitter spreads retries while keeping every retry delay capped.

## Validation

- `node node_modules/jest/bin/jest.js src/application/services/stellar-queue.integration.spec.ts --runInBand`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false`
- `git diff --check`

## Notes

Targeted ESLint could not run because the repository currently uses legacy `.eslintrc.js` while installed ESLint 9 expects flat config, and the legacy fallback cannot resolve `@typescript-eslint/recommended`. I did not change global lint configuration in this PR because the issue scope is retry backoff.
